### PR TITLE
chore: expand .gitignore for C++/JUCE/CMake projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,55 @@
+# === Build Artifacts ===
 build/
+cmake-build*/
+out/
+*.o
+*.obj
+*.a
+*.lib
+*.so
+*.dylib
+*.dll
+*.exe
+
+# === IDE / Editor Files ===
+.vscode/
+.idea/
+*.xcodeproj/
+*.xcworkspace/
+*.sln
+*.vcxproj*
+*.suo
+*.user
+*.sdf
+*.opensdf
+*.ipch
+
+# === CMake ===
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps/
+
+# === JUCE ===
+JuceLibraryCode/
+*.jucer
+Builds/
+
+# === macOS ===
 .DS_Store
+*.dSYM/
+
+# === Windows ===
+Thumbs.db
+Desktop.ini
+*.pdb
+
+# === Package / Installer ===
+*.dmg
+*.pkg
+*.zip
+*.tar.gz


### PR DESCRIPTION
## Summary
Expands the `.gitignore` from 2 lines to comprehensive coverage for a C++/JUCE/CMake project.

### Added ignore rules for:
- **Build artifacts** — `build/`, `cmake-build*/`, object files, shared libraries, executables
- **IDE/Editor files** — VS Code, JetBrains, Xcode, Visual Studio
- **CMake generated files** — `CMakeCache.txt`, `CMakeFiles/`, `compile_commands.json`
- **JUCE specific** — `JuceLibraryCode/`, `Builds/`
- **Platform files** — `.DS_Store`, `Thumbs.db`, `.dSYM/`
- **Packages/Installers** — `.dmg`, `.pkg`, `.zip`, `.tar.gz`

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore patterns to exclude build artifacts, IDE files, CMake outputs, platform-specific files, and packaging artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->