### PR TITLE
docs: add CHANGELOG.md following Keep a Changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to FreeEQ8 will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- 8-band parametric EQ with VST3/AU support
+- Linear phase mode
+- Dynamic EQ per band
+- Match EQ functionality
+- Per-band drive/saturation
+- Band linking
+- macOS and Windows build scripts
+- Contributing guidelines and code of conduct
+
+### Changed
+- Expanded `.gitignore` for comprehensive C++/JUCE/CMake coverage
+
+---
+
+> **Note:** ProEQ8 (0) is planned — 24 bands, 4 saturation modes, A/B comparison.


### PR DESCRIPTION
## Summary
Adds a `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/) format with semantic versioning.

Documents current features of FreeEQ8 and the recent `.gitignore` improvement. Sets up a structure for tracking future releases including ProEQ8.

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CHANGELOG documenting project history and planned features including 8-band parametric EQ with VST3/AU support, linear phase mode, dynamic EQ, match EQ, per-band drive/saturation, and band linking.

* **Chores**
  * Updated .gitignore for comprehensive coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->